### PR TITLE
Added __DIR__ to the inclusion of /vendor/autoload

### DIFF
--- a/src/Mpesa.php
+++ b/src/Mpesa.php
@@ -7,7 +7,7 @@
  */
 namespace Safaricom\Mpesa;
 
-include_once("../vendor/autoload.php");
+include_once(__DIR__."../vendor/autoload.php");
 
 use Symfony\Component\Dotenv\Dotenv;
 


### PR DESCRIPTION
This fixes the autoload inclusion error when the public folder's location is changed.