### PR TITLE
Added __DIR__ during vendor autoload inclusion

### DIFF
--- a/src/Mpesa.php
+++ b/src/Mpesa.php
@@ -7,7 +7,7 @@
  */
 namespace Safaricom\Mpesa;
 
-include_once("../vendor/autoload.php");
+include_once(__DIR__."../vendor/autoload.php");
 
 use Symfony\Component\Dotenv\Dotenv;
 

--- a/src/Mpesa.php
+++ b/src/Mpesa.php
@@ -7,7 +7,7 @@
  */
 namespace Safaricom\Mpesa;
 
-include_once(__DIR__."../vendor/autoload.php");
+include_once(__DIR__."/../vendor/autoload.php");
 
 use Symfony\Component\Dotenv\Dotenv;
 


### PR DESCRIPTION
This fixes the inclusion error when the location of the public directory is changed, mainly during deployment on CPanel sites.